### PR TITLE
Add parens to PubNub.ngHereNow call

### DIFF
--- a/app/views/_content.html.haml
+++ b/app/views/_content.html.haml
@@ -126,7 +126,7 @@
                 console.log('got a presence event:', payload);
               })
 
-              PubNub.ngHereNow { channel: theChannel }
+              PubNub.ngHereNow ({ channel: theChannel })
 
         %p
           Using the presence event as a trigger, we retrieve the Presence


### PR DESCRIPTION
Missing parens (found by a customer and reported to support).
`PubNub.ngHereNow { channel: theChannel }`
should be
`PubNub.ngHereNow ({ channel: theChannel })`
